### PR TITLE
FreeBSD doesn't have any requirements, sysctl is part of the base system

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,7 @@
   ansible.builtin.package:
     name: "{{ sysctl_requirements }}"
     state: present
+  when: sysctl_requirements | length > 0
 
 - name: set sysctl setting
   ansible.posix.sysctl:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,5 +6,6 @@ _sysctl_requirements:
     - procps
   RedHat:
     - procps-ng
+  FreeBSD:
 
 sysctl_requirements: "{{ _sysctl_requirements[ansible_os_family] | default(_sysctl_requirements['default'] ) }}"


### PR DESCRIPTION
I'm not 100% this is the best way to achieve this... but it works.
FreeBSD doesn't need any package(s) installed.